### PR TITLE
fix: NSIS installer with path selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # Build output
 dist
 out
+build/icons
 
 # OS files
 .DS_Store

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -18,6 +18,9 @@ nsis:
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
+  oneClick: false
+  allowToChangeInstallationDirectory: true
+  perMachine: false
 mac:
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:


### PR DESCRIPTION
- Enable full NSIS installer wizard with installation path selection
- Add allowToChangeInstallationDirectory option
- Add build/icons to .gitignore